### PR TITLE
requirements: Specify localhost as an IPv4 address

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
---index-url=http://localhost:8080/simple/
+--index-url=http://127.0.0.1:8080/simple/
 requests==2.32.3 \
     --hash=sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760 \
     --hash=sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6


### PR DESCRIPTION
It's common that "localhost" translates with both IPv4 and IPv6. The simple containerized test PyPI server we use in our CI doesn't listen on IPv6 which may cause unpredictable issues on hosts where IPv6 is enabled and IPv6 would get prioritized by the low level network stack connection primitives.